### PR TITLE
Conan install from cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,9 +2,21 @@ cmake_minimum_required(VERSION 3.9)
 
 project(Ymir)
 
+# Download automatically, you can also just copy the conan.cmake file
+if(NOT EXISTS "${CMAKE_BINARY_DIR}/conan.cmake")
+   message(STATUS "Downloading conan.cmake from https://github.com/conan-io/cmake-conan")
+   file(DOWNLOAD "https://github.com/conan-io/cmake-conan/raw/v0.13/conan.cmake"
+                 "${CMAKE_BINARY_DIR}/conan.cmake")
+endif()
+
+include(${CMAKE_BINARY_DIR}/conan.cmake)
+
+conan_cmake_run(REQUIRES gtest/1.8.1@bincrafters/stable
+                BASIC_SETUP
+                BUILD missing)
+
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup()
-
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED on)

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,5 +1,0 @@
-[requires]
-gtest/1.8.1@bincrafters/stable
-
-[generators]
-cmake


### PR DESCRIPTION
Альтернативный вариант использования conan
В этом варианте не нужна команда `conan install ..`
Все устанавливается из cmake
Есть минус - теперь нужно явно прописывать -DCMAKE_BUILD_TYPE=build_type
Где build_type - это тип сборки(Debug, Release)
@AntoninaFantalina как думаешь стоит перейти на этот вариант?